### PR TITLE
Don't pass CSS if `no_css` option is selected

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   run:
-    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
+    uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@1.x
     with:
       enable_backend_testing: false
       enable_phpstan: true

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -4,7 +4,7 @@ on: [workflow_dispatch, push, pull_request]
 
 jobs:
   run:
-    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@main
+    uses: flarum/framework/.github/workflows/REUSABLE_frontend.yml@1.x
     with:
       enable_bundlewatch: false
       enable_prettier: true

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -16,18 +16,16 @@ app.initializers.add('fof-cookie-consent', () => {
     const popup = {};
     const button = {};
 
-    if (backgroundColor) popup.background = backgroundColor;
-    if (textColor) popup.text = textColor;
+    if (ccTheme !== 'no_css') {
+      if (backgroundColor) popup.background = backgroundColor;
+      if (textColor) popup.text = textColor;
 
-    if (buttonBackgroundColor) button.background = buttonBackgroundColor;
-    if (buttonTextColor) button.text = buttonTextColor;
+      if (buttonBackgroundColor) button.background = buttonBackgroundColor;
+      if (buttonTextColor) button.text = buttonTextColor;
+    }
 
     try {
       const settings = {
-        palette: {
-          popup,
-          button,
-        },
         theme: ccTheme,
         content: {
           message: consentText,
@@ -36,6 +34,13 @@ app.initializers.add('fof-cookie-consent', () => {
           href: learnMoreLinkUrl,
         },
       };
+
+      if (ccTheme !== 'no_css') {
+        settings.palette = {
+          popup,
+          button,
+        };
+      }
 
       cookieconsent.initialise(settings);
     } catch (err) {

--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -3,53 +3,35 @@ import 'cookieconsent';
 
 app.initializers.add('fof-cookie-consent', () => {
   $(document).ready(() => {
-    const ccTheme = app.forum.attribute('fof-cookie-consent.ccTheme');
-    const backgroundColor = app.forum.attribute('fof-cookie-consent.backgroundColor');
-    const textColor = app.forum.attribute('fof-cookie-consent.textColor');
-    const consentText = app.forum.attribute('fof-cookie-consent.consentText');
-    const buttonText = app.forum.attribute('fof-cookie-consent.buttonText');
-    const buttonBackgroundColor = app.forum.attribute('fof-cookie-consent.buttonBackgroundColor');
-    const buttonTextColor = app.forum.attribute('fof-cookie-consent.buttonTextColor');
-    const learnMoreLinkText = app.forum.attribute('fof-cookie-consent.learnMoreLinkText');
-    const learnMoreLinkUrl = app.forum.attribute('fof-cookie-consent.learnMoreLinkUrl');
+    const getAttribute = (key) => app.forum.attribute(`fof-cookie-consent.${key}`);
 
-    const popup = {};
-    const button = {};
+    let settings = {
+      theme: getAttribute('ccTheme'),
+      content: {
+        message: getAttribute('consentText'),
+        dismiss: getAttribute('buttonText'),
+        link: getAttribute('learnMoreLinkText'),
+        href: getAttribute('learnMoreLinkUrl'),
+      },
+    };
 
-    if (ccTheme !== 'no_css') {
-      if (backgroundColor) popup.background = backgroundColor;
-      if (textColor) popup.text = textColor;
-
-      if (buttonBackgroundColor) button.background = buttonBackgroundColor;
-      if (buttonTextColor) button.text = buttonTextColor;
+    if (getAttribute('ccTheme') !== 'no_css') {
+      settings.palette = {
+        popup: {
+          background: getAttribute('backgroundColor') || undefined,
+          text: getAttribute('textColor') || undefined,
+        },
+        button: {
+          background: getAttribute('buttonBackgroundColor') || undefined,
+          text: getAttribute('buttonTextColor') || undefined,
+        },
+      };
     }
 
     try {
-      const settings = {
-        theme: ccTheme,
-        content: {
-          message: consentText,
-          dismiss: buttonText,
-          link: learnMoreLinkText,
-          href: learnMoreLinkUrl,
-        },
-      };
-
-      if (ccTheme !== 'no_css') {
-        settings.palette = {
-          popup,
-          button,
-        };
-      }
-
       cookieconsent.initialise(settings);
     } catch (err) {
-      if (app.forum.attribute('adminUrl')) {
-        console.error('An error occurred initializing the Cookie Consent library. Please make sure you have set all the settings properly.');
-        console.error("Please report the following error if you don't think the issue is on your end\n\n", err);
-      } else {
-        console.error('An error occurred with the cookie consent prompt. Please contact an administrator so they can fix the issue.');
-      }
+      console.error('An error occurred initializing the Cookie Consent library:', err);
     }
 
     delete window.cookieconsent;

--- a/src/Providers/AssetProvider.php
+++ b/src/Providers/AssetProvider.php
@@ -20,7 +20,7 @@ class AssetProvider extends AbstractServiceProvider
     public function boot()
     {
         $this->container->resolving('flarum.assets.forum', function (Assets $assets) {
-            if (resolve('flarum.settings')->get('reflar-cookie-consent.ccTheme') != 'no_css') {
+            if (resolve('flarum.settings')->get('fof-cookie-consent.ccTheme') != 'no_css') {
                 $assets->css(function (SourceCollector $sources) {
                     $sources->addFile(__DIR__.'/../../resources/less/forum.less');
                 });


### PR DESCRIPTION
**Fixes #37**

**Changes proposed in this pull request:**
Ensure that no additional CSS is used when the `no_css` option is selected.

**Reviewers should focus on:**
During debugging, I've discovered an edge case or two, which we should cover in the future. Actually, to be frank, I think this one needs a major refactor.

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
